### PR TITLE
Added a second "become sponsor" button

### DIFF
--- a/src/main/resources/templates/Application/index.html
+++ b/src/main/resources/templates/Application/index.html
@@ -300,6 +300,10 @@
             {m:views.application.index.sponsors}
         </h2>
 
+        <div class="partenaires__buttonContainer">
+            <a class="button" href="{sponsoringLeafletUrl}">{m:views.application.index.sponsors.join}</a>
+        </div>
+
         {#if sponsors != null && !sponsors.isEmpty()}
             <div class="partenaires__levels">
                 {#for sponsorShip in sponsors.keySet()}


### PR DESCRIPTION
The current "become sponsor" button was buried under the (long) list of previous sponsors, so I added a second one on top of the list of sponsors (current+past).