### PR TITLE
More padding space after the first "Become sponsor" button

### DIFF
--- a/src/main/resources/templates/Application/index.html
+++ b/src/main/resources/templates/Application/index.html
@@ -300,7 +300,7 @@
             {m:views.application.index.sponsors}
         </h2>
 
-        <div class="partenaires__buttonContainer">
+        <div class="partenaires__buttonContainer" style="padding-bottom: 40px;">
             <a class="button" href="{sponsoringLeafletUrl}">{m:views.application.index.sponsors.join}</a>
         </div>
 


### PR DESCRIPTION
Button is currently too close to the "Diamond" sponsor.